### PR TITLE
Include an example of a label with square brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - "[Status] Maybe Later"
 # Label to use when marking as stale
 staleLabel: wontfix
 # Comment to post when marking as stale. Set to `false` to disable


### PR DESCRIPTION
See #71

Stale gets confused when label names use square brackets. Until this is fixed, let's show that one can work around that problem by adding quotes around the label.